### PR TITLE
Fix duration parsing to be case-insensitive

### DIFF
--- a/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java
+++ b/dropwizard-util/src/main/java/io/dropwizard/util/Duration.java
@@ -85,7 +85,8 @@ public class Duration implements Comparable<Duration>, Serializable {
         }
 
         final long count = Long.parseLong(matcher.group(1));
-        final TimeUnit unit = SUFFIXES.get(matcher.group(2));
+        final String unitKey = matcher.group(2).toLowerCase(Locale.ENGLISH);
+        final TimeUnit unit = SUFFIXES.get(unitKey);
         if (unit == null) {
             throw new IllegalArgumentException("Invalid duration: " + duration + ". Wrong time unit");
         }

--- a/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
+++ b/dropwizard-util/src/test/java/io/dropwizard/util/DurationTest.java
@@ -155,6 +155,15 @@ public class DurationTest {
     }
 
     @Test
+    public void parsesUnitsCaseInsensitively() {
+        assertThat(Duration.parse("5 Seconds"))
+            .isEqualTo(Duration.seconds(5));
+
+        assertThat(Duration.parse("1 MINUTE"))
+            .isEqualTo(Duration.minutes(1));
+    }
+
+    @Test
     public void unableParseWrongDurationCount() {
         assertThatIllegalArgumentException().isThrownBy(() -> Duration.parse("five seconds"));
     }


### PR DESCRIPTION
## Summary
- handle case-insensitive units when parsing `Duration`
- test parsing of mixed-case duration units

## Testing
- `mvn -q -pl dropwizard-util test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684095dea07c83269351964cfd5c8854